### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/completeWorkflow.yaml
+++ b/.github/workflows/completeWorkflow.yaml
@@ -4,9 +4,14 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   pipeline:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout do código


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123012/BattleShip2/security/code-scanning/9](https://github.com/IGE-123012/BattleShip2/security/code-scanning/9)

Add an explicit `permissions:` block to the workflow file so the `GITHUB_TOKEN` is scoped with least privilege.  
Best single fix here is:

- Define baseline read-only permission at workflow root:
  - `contents: read`
- Override at the job level only where write access is needed:
  - for publishing to GitHub Pages via `peaceiris/actions-gh-pages`, set `contents: write` on `jobs.pipeline.permissions`.

This keeps behavior intact (the publish step still works) while ensuring explicit, minimal permissions are declared.

File to edit:
- `.github/workflows/completeWorkflow.yaml`
  - Add root `permissions` after `on: ...`
  - Add `jobs.pipeline.permissions` before `steps`.

No imports/dependencies/methods needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
