### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,6 +1,9 @@
 # Número de Aluno: 122996 - Nome: Laura Coelho
 name: SonarCloud Analysis
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123012/BattleShip2/security/code-scanning/8](https://github.com/IGE-123012/BattleShip2/security/code-scanning/8)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` follows least privilege.  
Best fix here (without changing behavior) is at workflow root, so it applies to all jobs unless overridden.

For `.github/workflows/sonarcloud.yml`, insert:

```yml
permissions:
  contents: read
```

immediately after the `name` (or before `jobs`). This matches CodeQL’s minimal recommendation and is typically sufficient for checkout + analysis workflows like this one.

No imports, methods, or external definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
