### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qodana_godclass.yml
+++ b/.github/workflows/qodana_godclass.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   qodana:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123012/BattleShip2/security/code-scanning/7](https://github.com/IGE-123012/BattleShip2/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `qodana`) unless overridden. The safest minimal fix, aligned with the warning and current behavior, is:

- `permissions:`
  - `contents: read`

This should be inserted in `.github/workflows/qodana_godclass.yml` after the workflow triggers (`on:` block) and before `jobs:`.  
No imports, methods, or additional definitions are needed (YAML workflow only).  
This preserves existing functionality while documenting and enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
